### PR TITLE
Create performChanEstimation

### DIFF
--- a/performChanEstimation
+++ b/performChanEstimation
@@ -1,0 +1,26 @@
+function [EstChanLS,EstChanMMSE] = performChanEstimation(ReceivedData,PilotSeq,RHH,NoiseVar,NumPilot,NumSC,NumPath,idxSC)
+% This function is to perform LS and MMSE channel estimations using pilot
+% symbols, second-order statistics of the channel and noise variance [1].
+
+% [1] O. Edfors, M. Sandell, J. -. van de Beek, S. K. Wilson and 
+% P. Ola Borjesson, "OFDM channel estimation by singular value 
+% decomposition," VTC, Atlanta, GA, USA, 1996, pp. 923-927 vol.2.
+PilotSpacing = NumSC/NumPilot;
+%%%%%%%%%%%%%%% LS estimation with interpolation %%%%%%%%%%%%%%%%%%%%%%%%%
+H_LS = ReceivedData(1:PilotSpacing:NumSC)./PilotSeq;
+H_LS_interp = interp1(1:PilotSpacing:NumSC,H_LS,1:NumSC,'linear','extrap');
+H_LS_interp = H_LS_interp.';
+%%%%%%%%%%%%%%%% MMSE estimation based on LS %%%%%%%%%%%%%%%%
+[U,D,V] = svd(RHH);
+d = diag(D);
+InvertValue = zeros(NumSC,1);
+if NumPilot >= NumPath
+    InvertValue(1:NumPilot) = d(1:NumPilot)./(d(1:NumPilot)+NoiseVar);
+else
+    InvertValue(1:NumPath) = d(1:NumPath)./(d(1:NumPath)+NoiseVar);
+end
+H_MMSE = U*diag(InvertValue)*V'*H_LS_interp;
+%%%%%%%%%%%%%%% Channel coefficient on the selected subcarrier %%%%%%%%%%%
+EstChanLS = H_LS_interp(idxSC);
+EstChanMMSE = H_MMSE(idxSC);
+end


### PR DESCRIPTION
This function is to perform LS and MMSE channel estimations using pilot symbols, second-order statistics of the channel and noise variance